### PR TITLE
access for all url patch

### DIFF
--- a/src/de/accessibility/roles/product-owner/product-owner.md
+++ b/src/de/accessibility/roles/product-owner/product-owner.md
@@ -21,4 +21,4 @@ Issues zur Barrierefreiheit versinken gerne im Backlog. Versuche sie gegenüber 
 ## <sbb-icon name="circle-tick-medium"></sbb-icon> Plane ein externes Review frühzeitig ein{.with-icon}
 Plane genügend Zeit für ein externes Review oder eine <sbb-link variant="inline" type="button" href="/{{page.lang}}/accessibility/introduction/further-information/">Zertifizierung</sbb-link> der Barrierefreiheit ein. Ein typisches Review durch Zugang für alle nimmt etwa zwei Wochen in Anspruch. Dies solltest du idealerweise mindestens zwei Monate zuvor anmelden.{.lead}
 
-Weitere Informationen: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/ch/beratung.html">https://access-for-all.ch/ch/beratung.html</sbb-link>
+Weitere Informationen: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/leistungen/beratung/">https://access-for-all.ch/leistungen/beratung/</sbb-link>

--- a/src/en/accessibility/roles/product-owner/product-owner.md
+++ b/src/en/accessibility/roles/product-owner/product-owner.md
@@ -21,4 +21,4 @@ Accessibility issues are easily deprioritized in the backlog. Try to prioritise 
 ## <sbb-icon name="circle-tick-medium"></sbb-icon> Plan an external review promptly{.with-icon}
 Ensure sufficient time when planning an external review or any <sbb-link variant="inline" type="button" href="/{{page.lang}}/accessibility/introduction/further-information/">certification</sbb-link> of accessibility. A typical review through Access For All takes around two weeks. Ideally, you should register for this at least two months in advance.{.lead}
 
-Further information: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/ch/beratung.html">https://access-for-all.ch/ch/beratung.html</sbb-link>
+Further information: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/leistungen/beratung/">https://access-for-all.ch/leistungen/beratung/</sbb-link>

--- a/src/fr/accessibility/introduction/further-information/further-information.md
+++ b/src/fr/accessibility/introduction/further-information/further-information.md
@@ -24,7 +24,7 @@ order: 4
 ## Documents pour la certification
 * Directives pour l’accessibilité des contenus Web (WCAG). Recommandations sur lesquelles se fondent la certification et les fondements juridiques (en anglais uniquement): <sbb-link variant="inline" type="button" target="_blank" href="https://www.w3.org/TR/WCAG21">https://www.w3.org/TR/WCAG21</sbb-link>
 * Liste de contrôle complète pour les certifications établie sur la base des directives WCAG: <sbb-link variant="inline" type="button" target="_blank" href="http://www.accessibility-checklist.ch">http://www.accessibility-checklist.ch</sbb-link>
-* Prestations de conseil de la fondation Accès pour tous (en allemand ou anglais): <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/leistungen/beratung/">https://access-for-all.ch/leistungen/beratung/</sbb-link>
+* Prestations de conseil de la fondation Accès pour tous (en allemand ou anglais): <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/fr/consultation/">https://access-for-all.ch/fr/consultation/</sbb-link>
 
 
 ## Principales sources d’inspiration pour ce guide

--- a/src/fr/accessibility/roles/product-owner/product-owner.md
+++ b/src/fr/accessibility/roles/product-owner/product-owner.md
@@ -21,4 +21,4 @@ Avec le temps, les questions relatives à l’accessibilité passent souvent au 
 ## <sbb-icon name="circle-tick-medium"></sbb-icon> Planifie dès que possible un audit externe{.with-icon}
 Prévois des délais suffisants si tu dois planifier un audit externe ou une  <sbb-link variant="inline" type="button" href="/{{page.lang}}/accessibility/introduction/further-information/">certification</sbb-link> de l’accessibilité. Un audit type effectué par Accès pour tous prend environ deux semaines. Dans l’idéal, un tel audit doit être annoncé au moins deux mois à l’avance.{.lead}
 
-Plus d’informations: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/fr/services-2/consultation/">https://access-for-all.ch/fr/services-2/consultation/</sbb-link>
+Plus d’informations: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/fr/consultation/">https://access-for-all.ch/fr/consultation/</sbb-link>

--- a/src/fr/accessibility/roles/product-owner/product-owner.md
+++ b/src/fr/accessibility/roles/product-owner/product-owner.md
@@ -21,4 +21,4 @@ Avec le temps, les questions relatives à l’accessibilité passent souvent au 
 ## <sbb-icon name="circle-tick-medium"></sbb-icon> Planifie dès que possible un audit externe{.with-icon}
 Prévois des délais suffisants si tu dois planifier un audit externe ou une  <sbb-link variant="inline" type="button" href="/{{page.lang}}/accessibility/introduction/further-information/">certification</sbb-link> de l’accessibilité. Un audit type effectué par Accès pour tous prend environ deux semaines. Dans l’idéal, un tel audit doit être annoncé au moins deux mois à l’avance.{.lead}
 
-Plus d’informations: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/ch/beratung.html">https://access-for-all.ch/ch/beratung.html</sbb-link>
+Plus d’informations: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/fr/services-2/consultation/">https://access-for-all.ch/fr/services-2/consultation/</sbb-link>

--- a/src/it/accessibility/roles/product-owner/product-owner.md
+++ b/src/it/accessibility/roles/product-owner/product-owner.md
@@ -21,4 +21,4 @@ Gli aspetti legati all’accessibilità senza barriere slittano spesso in second
 ## <sbb-icon name="circle-tick-medium"></sbb-icon> Pianifica fin dalle prime fasi una revisione esterna{.with-icon}
 Metti in conto il tempo sufficiente per una revisione esterna o una <sbb-link variant="inline" type="button" href="/{{page.lang}}/accessibility/introduction/further-information/">certificazione</sbb-link> dell’accessibilità. Di norma, per una revisione da parte di Access For All servono circa due settimane. Inoltre, idealmente sarebbe opportuno richiedere la revisione almeno due mesi prima.{.lead}
 
-Ulteriori informazioni: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/ch/beratung.html">https://access-for-all.ch/ch/beratung.html</sbb-link>
+Ulteriori informazioni: <sbb-link variant="inline" type="button" target="_blank" href="https://access-for-all.ch/leistungen/beratung/">https://access-for-all.ch/leistungen/beratung/</sbb-link>


### PR DESCRIPTION
This patch does 2 things

1. the links to the access-for-all consultation in src/xx/accessibility/roles/product-owner/product-owner.md were outdated and had to be fixed. The correct links were already present at src/xx/accessibility/introduction/further-information/further-information.md 
2. replace the links about the access-for-all consultation to those for the French page in product-owner.md & further-information.md